### PR TITLE
Add basic lexer with token types and unit tests

### DIFF
--- a/internal/lexer/lexer.go
+++ b/internal/lexer/lexer.go
@@ -1,0 +1,42 @@
+package lexer
+
+import (
+	"strings"
+)
+
+// TokenType — тип токенів
+type TokenType string
+
+const (
+	TOKEN_HAI     TokenType = "HAI"
+	TOKEN_VISIBLE TokenType = "VISIBLE"
+	TOKEN_KTHXBYE TokenType = "KTHXBYE"
+	TOKEN_UNKNOWN TokenType = "UNKNOWN"
+)
+
+// Token — структура токена
+type Token struct {
+	Type    TokenType
+	Literal string
+}
+
+// Tokenize — базовий лексичний аналізатор
+func Tokenize(input string) []Token {
+	words := strings.Fields(input)
+	var tokens []Token
+
+	for _, word := range words {
+		switch word {
+		case "HAI":
+			tokens = append(tokens, Token{Type: TOKEN_HAI, Literal: word})
+		case "VISIBLE":
+			tokens = append(tokens, Token{Type: TOKEN_VISIBLE, Literal: word})
+		case "KTHXBYE":
+			tokens = append(tokens, Token{Type: TOKEN_KTHXBYE, Literal: word})
+		default:
+			tokens = append(tokens, Token{Type: TOKEN_UNKNOWN, Literal: word})
+		}
+	}
+
+	return tokens
+}

--- a/tests/lexer_test.go
+++ b/tests/lexer_test.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/SVersj/go-lolcode/internal/lexer"
+)
+
+func TestTokenize(t *testing.T) {
+	input := "HAI VISIBLE Hello KTHXBYE"
+	expected := []lexer.Token{
+		{Type: lexer.TOKEN_HAI, Literal: "HAI"},
+		{Type: lexer.TOKEN_VISIBLE, Literal: "VISIBLE"},
+		{Type: lexer.TOKEN_UNKNOWN, Literal: "Hello"},
+		{Type: lexer.TOKEN_KTHXBYE, Literal: "KTHXBYE"},
+	}
+
+	tokens := lexer.Tokenize(input)
+
+	if len(tokens) != len(expected) {
+		t.Fatalf("expected %d tokens, got %d", len(expected), len(tokens))
+	}
+
+	for i, tok := range tokens {
+		if tok != expected[i] {
+			t.Errorf("token %d: expected %+v, got %+v", i, expected[i], tok)
+		}
+	}
+}


### PR DESCRIPTION
### Що зроблено:
- Реалізовано базовий `lexer.go`, що розпізнає:
  - `HAI`
  - `VISIBLE`
  - `KTHXBYE`
- Додано тести `lexer_test.go` на базову перевірку
- Підготовлено до наступного кроку: parser

👀 Очікую code review!
