### PR TITLE
Add basic parser with VISIBLE statement support

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,35 @@
+package parser
+
+import (
+	"errors"
+	"github.com/SVersj/go-lolcode/internal/lexer"
+)
+
+type Statement struct {
+	Command string
+	Args    []string
+}
+
+func Parse(tokens []lexer.Token) ([]Statement, error) {
+	var statements []Statement
+
+	if len(tokens) < 2 || tokens[0].Type != lexer.TOKEN_HAI || tokens[len(tokens)-1].Type != lexer.TOKEN_KTHXBYE {
+		return nil, errors.New("program must start with HAI and end with KTHXBYE")
+	}
+
+	for i := 1; i < len(tokens)-1; i++ {
+		token := tokens[i]
+
+		if token.Type == lexer.TOKEN_VISIBLE {
+			if i+1 < len(tokens) {
+				arg := tokens[i+1].Literal
+				statements = append(statements, Statement{Command: "VISIBLE", Args: []string{arg}})
+				i++ // Пропускаємо аргумент
+			} else {
+				return nil, errors.New("VISIBLE without argument")
+			}
+		}
+	}
+
+	return statements, nil
+}

--- a/tests/parser_test.go
+++ b/tests/parser_test.go
@@ -1,0 +1,29 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/SVersj/go-lolcode/internal/lexer"
+	"github.com/SVersj/go-lolcode/internal/parser"
+)
+
+func TestParse(t *testing.T) {
+	tokens := lexer.Tokenize("HAI VISIBLE Hello KTHXBYE")
+
+	statements, err := parser.Parse(tokens)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(statements))
+	}
+
+	stmt := statements[0]
+	if stmt.Command != "VISIBLE" {
+		t.Errorf("expected VISIBLE command, got %s", stmt.Command)
+	}
+	if len(stmt.Args) != 1 || stmt.Args[0] != "Hello" {
+		t.Errorf("expected argument 'Hello', got %v", stmt.Args)
+	}
+}


### PR DESCRIPTION
### 🔧 Що зроблено:

- Реалізовано базову логіку `parser.go`, яка:
  - перевіряє початок програми (`HAI`)
  - розпізнає інструкцію `VISIBLE arg`
  - перевіряє завершення програми (`KTHXBYE`)

- Створено структуру `Statement`:
```go
type Statement struct {
	Command string
	Args    []string
}
