### PR TITLE
Add basic interpreter to handle VISIBLE statements

### DIFF
--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -1,0 +1,20 @@
+package interpreter
+
+import (
+	"fmt"
+	"github.com/SVersj/go-lolcode/internal/parser"
+)
+
+func Run(statements []parser.Statement) error {
+	for _, stmt := range statements {
+		switch stmt.Command {
+		case "VISIBLE":
+			for _, arg := range stmt.Args {
+				fmt.Println(arg)
+			}
+		default:
+			return fmt.Errorf("unsupported command: %s", stmt.Command)
+		}
+	}
+	return nil
+}

--- a/tests/interpreter_test.go
+++ b/tests/interpreter_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"bytes"
+	"github.com/SVersj/go-lolcode/internal/interpreter"
+	"github.com/SVersj/go-lolcode/internal/parser"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRun(t *testing.T) {
+	statements := []parser.Statement{
+		{Command: "VISIBLE", Args: []string{"Hello", "World"}},
+	}
+
+	// Перехоплюємо stdout
+	var buf bytes.Buffer
+	stdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	_ = interpreter.Run(statements)
+
+	w.Close()
+	os.Stdout = stdout
+	_, _ = buf.ReadFrom(r)
+
+	output := buf.String()
+	expected := "Hello\nWorld\n"
+
+	if strings.TrimSpace(output) != strings.TrimSpace(expected) {
+		t.Errorf("expected output:\n%s\ngot:\n%s", expected, output)
+	}
+}


### PR DESCRIPTION
### 🔧 Що зроблено:

- Реалізовано `interpreter.go` з функцією `Run`, яка виконує інструкції:
  - `VISIBLE Hello` → друкує `Hello` в консоль

- Написано `interpreter_test.go`:
  - перехоплює stdout
  - порівнює фактичний вивід із очікуваним

```go
expected := "Hello\\nWorld\\n"
